### PR TITLE
add role.yaml

### DIFF
--- a/iris/templates/role.yaml
+++ b/iris/templates/role.yaml
@@ -6,7 +6,7 @@ metadata:
 rules:
   - apiGroups: [""]
     verbs: ["get", "list", "watch"]
-    resources: ["events"]
+    resources: ["events", "configmaps", "nodes", "pods"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/iris/templates/role.yaml
+++ b/iris/templates/role.yaml
@@ -6,7 +6,7 @@ metadata:
 rules:
   - apiGroups: [""]
     verbs: ["get", "list", "watch"]
-    resources: ["events", "configmaps", "nodes", "pods"]
+    resources: ["events", "configmaps", "pods"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/iris/templates/role.yaml
+++ b/iris/templates/role.yaml
@@ -1,8 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: iris-role
-  namespace: iris
+  name: {{ template "fullname" . }}
+  namespace: {{ .Values.namespace }}
 rules:
   - apiGroups: [""]
     verbs: ["get", "list", "watch"]
@@ -12,13 +12,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: iris-role-rolebinding
-  namespace: iris
+  name: {{ template "fullname" . }}
+  namespace: {{ .Values.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: iris-role
+  name: {{ template "fullname" . }}
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: iris
+  namespace: {{ .Values.namespace }}

--- a/iris/templates/role.yaml
+++ b/iris/templates/role.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: iris-role
+  namespace: iris
+rules:
+  - apiGroups: [""]
+    verbs: ["get", "list", "watch"]
+    resources: ["events"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: iris-role-rolebinding
+  namespace: iris
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: iris-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: iris


### PR DESCRIPTION
HI dude.

I run introduction, don't work...

```
$ helm install ./iris --values ./iris.yaml
```

And, I suggest, If it needs rolebinding `default` serviceaccount.
do you think?

for example I apply this `role.yaml`, it's running!!

```
$ helm install ./iris --values ./iris.yaml
 NAME:   volted-seahorse
LAST DEPLOYED: Sun Aug 12 02:36:46 2018
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1/Namespace
NAME  STATUS  AGE
iris  Active  0s

==> v1/ConfigMap
NAME                  DATA  AGE
volted-seahorse-iris  1     0s

==> v1/ClusterRole
NAME                  AGE
volted-seahorse-iris  0s

==> v1/ClusterRoleBinding
NAME                  AGE
volted-seahorse-iris  0s

==> v1beta1/Deployment
NAME                  DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
volted-seahorse-iris  1        1        1           0          0s

==> v1/Pod(related)
NAME                                   READY  STATUS   RESTARTS  AGE
volted-seahorse-iris-56d6cb4dcf-rm6cd  0/1    Pending  0         0s

$ k log volted-seahorse-iris-56d6cb4dcf-rm6cd  -n iris
log is DEPRECATED and will be removed in a future version. Use logs instead.
Started
Running from in cluster
[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:   export GIN_MODE=release
 - using code:  gin.SetMode(gin.ReleaseMode)
[GIN-debug] Environment variable PORT is undefined. Using port :8080 by default
[GIN-debug] Listening and serving HTTP on :8080
Server started
Watching
```