### PR TITLE
Imple slack post

### DIFF
--- a/pkg/dal/destination.go
+++ b/pkg/dal/destination.go
@@ -80,7 +80,7 @@ func execSlackWebHook(d *Destination, payload interface{}) {
 	resp, _ := client.Do(req)
 	defer resp.Body.Close()
 	body, _ := ioutil.ReadAll(resp.Body)
-	if string(body) != "ok" {
+	if string(body) == "ok" {
 		fmt.Printf("Execute Slack POST Success.")
 	} else {
 		fmt.Printf("Error:\nStatus Code: %d\nBody: %s\n", resp.StatusCode, string(body))

--- a/pkg/dal/destination.go
+++ b/pkg/dal/destination.go
@@ -40,6 +40,8 @@ func (d *Destination) Exec(payload interface{}) {
 	fmt.Printf("Executing destination %s\n", d.Name)
 	if d.Type == "" {
 		execDefault(d, payload)
+	} else if d.Type == "SlackWebHook" {
+		execSlackWebHook(d, payload)
 	} else if d.Type == "Codefresh" {
 		execCodefresh(d, payload)
 	}
@@ -54,6 +56,35 @@ func execDefault(d *Destination, payload interface{}) {
 	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{}
 	client.Do(req)
+}
+
+func execSlackWebHook(d *Destination, payload interface{}) {
+	fmt.Printf("Executing SlackWebHook destination to %s\n", d.URL)
+	pJSON, err := json.MarshalIndent(payload, "", "   ")
+	if err != nil {
+		fmt.Println(err)
+	}
+	var slackPayload = map[string]interface{}{"text": string(pJSON)}
+	mJSON, err := json.Marshal(slackPayload)
+	if err != nil {
+		fmt.Println(err)
+	}
+	contentReader := bytes.NewReader(mJSON)
+	req, err := http.NewRequest("POST", d.URL, contentReader)
+	if err != nil {
+		fmt.Println(err)
+	}
+	req.Header.Set("X-IRIS-HMAC", getHmac(d.Secret, mJSON))
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+	resp, _ := client.Do(req)
+	defer resp.Body.Close()
+	body, _ := ioutil.ReadAll(resp.Body)
+	if string(body) != "ok" {
+		fmt.Printf("Execute Slack POST Success.")
+	} else {
+		fmt.Printf("Error:\nStatus Code: %d\nBody: %s\n", resp.StatusCode, string(body))
+	}
 }
 
 func execCodefresh(d *Destination, payload interface{}) {

--- a/pkg/dal/destination.go
+++ b/pkg/dal/destination.go
@@ -81,7 +81,7 @@ func execSlackWebHook(d *Destination, payload interface{}) {
 	defer resp.Body.Close()
 	body, _ := ioutil.ReadAll(resp.Body)
 	if string(body) == "ok" {
-		fmt.Printf("Execute Slack POST Success.")
+		fmt.Printf("Execute Slack POST Success.\n")
 	} else {
 		fmt.Printf("Error:\nStatus Code: %d\nBody: %s\n", resp.StatusCode, string(body))
 	}


### PR DESCRIPTION
Hi dude.
I imple Slack web hook type.
because,
- slack webhook json format is {"text":*JSON STRING*}, execDefault is unformattable
- POST row JSON,  hard to see 😑

It's PR merge,
And config, for example,
```
filters:
  - name: MatchDefaultNamespace
    type: namespace
    namespace: default
  - name: MatchPodKind
    type: jsonpath
    path: $.involvedObject.kind
    value: Pod

destinations:
  - name: prod
    type: SlackWebHook
    url: https://hooks.slack.com/services/XXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXX

integrations:
  - name: Report
    destinations:
    - prod
    filters:
    - MatchPodKind
    - MatchDefaultNamespace
```

Looks Cool! 👍
![screen shot 0030-08-12 at 14 28 44](https://user-images.githubusercontent.com/17565502/43998922-1948b182-9e3c-11e8-9997-541aad1c5330.png)
