### PR TITLE
Change Dockerfile to multistage, build binary in docker for CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-FROM alpine:3.8
+FROM golang as builder
+RUN mkdir -p /build/dist
+ADD . /build/
+WORKDIR /build
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o dist/iris main.go
 
-RUN apk add --update ca-certificates
-
-COPY dist/linux_386/iris /usr/local/bin/
+FROM alpine:latest
+RUN apk --no-cache add --update ca-certificates
+COPY --from=builder /build/dist/iris /usr/local/bin/iris
 COPY hack/docker_entrypoint.sh /entrypoint.sh
 COPY VERSION /VERSION
 


### PR DESCRIPTION
Just a proposal to do the build for Docker during the build step.   That way the `Dockerfile` isn't dependent on the build environment to succeed.

Closes #39 